### PR TITLE
fix: force strict inequality on default `isCacheable` function to per…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export type SqliteStore = Store & {
 export type SqliteCache = Cache<SqliteStore>;
 
 export const sqliteStore = (options: SqliteStoreOptions): SqliteStore => {
-  const isCacheable = options?.isCacheable ?? ((val) => val != undefined);
+  const isCacheable = options?.isCacheable ?? ((val) => val !== undefined);
 
   const sqlite = new Database(options.sqliteFile);
   const tableName = options.cacheTableName;

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ CREATE INDEX IF NOT EXISTS idx_expired_caches ON ${tableName}(expiredAt);
     const trans = sqlite.transaction<(keys: string[]) => CacheObject[]>((keys) => {
       return keys
         .map((key) => selectStatement.get(key) as CacheObject | undefined)
-        .filter((data) => data != undefined && (data.expiredAt == -1 || data.expiredAt > ts)) as CacheObject[];
+        .filter((data) => data !== undefined && (data.expiredAt == -1 || data.expiredAt > ts)) as CacheObject[];
     });
 
     return trans(args);


### PR DESCRIPTION
This PR forces a strict inequality on the default "isCacheable" function to allow a null value

Similar to : https://github.com/jaredwray/cache-manager/blob/80270b83d380650ead74a6fbdcbc4c8d1ea9ab97/packages/cache-manager/src/stores/memory.ts#L38