### PR TITLE
feat: purge expired keys & fix: cluster mode compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import {join} from 'node:path';
 // SQLite :memory: cache store
 const memStoreCache = cacheManager.caching(sqliteStore({cacheTableName: 'caches'}));
 
-// On disk cache on employees table
+// On disk cache on caches table
 const sqliteStoreCache = cacheManager.caching(sqliteStore({sqliteFile: join(process.cwd(), 'cache.sqlite3'), cacheTableName: 'caches'}))
 ```
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -53,8 +53,7 @@ describe("set", () => {
     await expect(sqliteCacheTtl.get("foo")).resolves.toEqual("bar");
   });
 
-  it("should not be able to store a null value (not cacheable)", () =>
-    expect(sqliteCache.set("foo2", null)).rejects.toBeDefined());
+  it("should be able to store a null value", () => expect(sqliteCache.set("foo2", null)).resolves.toBeUndefined());
 
   it("should not store an invalid value", () =>
     expect(sqliteCache.set("foo1", undefined)).rejects.toStrictEqual(new Error("no cacheable value undefined")));
@@ -111,7 +110,7 @@ describe("mset", () => {
   });
 
   it("should not be able to store a null value (not cacheable)", () =>
-    expect(sqliteCache.store.mset([["foo2", null]])).rejects.toBeDefined());
+    expect(sqliteCache.store.mset([["foo2", null]])).resolves.toBeUndefined());
 
   it("should store a value without ttl", async () => {
     await sqliteCache.store.mset([

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,7 +7,6 @@ const sleep = (timeout: number) => new Promise((resolve) => setTimeout(resolve, 
 
 let sqliteCache: SqliteCache;
 let sqliteCacheTtl: SqliteCache;
-let sqliteCacheInMemory: SqliteCache;
 
 const sqliteFile = join(process.cwd(), "runtime", "cache.sqlite3");
 const cacheTableName = "caches";
@@ -40,11 +39,11 @@ describe("set", () => {
   });
 
   it("should store a value with a specific ttl from global", async () => {
-    await sqliteCacheTtl.set("foo", "bar");
+    await sqliteCacheTtl.set("foo333", "bar");
     await sleep(2);
-    await expect(sqliteCacheTtl.get("foo")).resolves.toEqual("bar");
+    await expect(sqliteCacheTtl.get("foo333")).resolves.toEqual("bar");
     await sleep(500);
-    await expect(sqliteCacheTtl.get("foo")).resolves.toBeUndefined();
+    await expect(sqliteCacheTtl.get("foo333")).resolves.toBeUndefined();
   });
 
   it("should store a value with 0 ttl", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ CREATE INDEX IF NOT EXISTS idx_expired_caches ON ${tableName}(expiredAt);
   );
   const deleteStatement = sqlite.prepare(`DELETE FROM ${tableName} WHERE cacheKey IN (?)`);
   const finderStatement = sqlite.prepare(
-    `SELECT cacheKey FROM ${tableName} WHERE cacheKey LIKE ? AND expiredAt = -1 OR expiredAt < ?`,
+    `SELECT cacheKey FROM ${tableName} WHERE cacheKey LIKE ? AND expiredAt = -1 OR expiredAt > ?`,
   );
   const purgeStatement = sqlite.prepare(`DELETE FROM ${tableName} WHERE expiredAt != -1 AND expiredAt < ?`);
   const emptyStatement = sqlite.prepare(`DELETE FROM ${tableName}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ CREATE INDEX IF NOT EXISTS idx_expired_caches ON ${tableName}(expiredAt);
   );
   const deleteStatement = sqlite.prepare(`DELETE FROM ${tableName} WHERE cacheKey IN (?)`);
   const finderStatement = sqlite.prepare(
-    `SELECT cacheKey FROM ${tableName} WHERE cacheKey LIKE ? AND expiredAt = -1 OR expiredAt > ?`,
+    `SELECT cacheKey FROM ${tableName} WHERE cacheKey LIKE ? AND (expiredAt = -1 OR expiredAt > ?)`,
   );
   const purgeStatement = sqlite.prepare(`DELETE FROM ${tableName} WHERE expiredAt != -1 AND expiredAt < ?`);
   const emptyStatement = sqlite.prepare(`DELETE FROM ${tableName}`);


### PR DESCRIPTION
- feat: allow expired records to be purged (standard behavior)
- fix: the method `keys` should return only the unexpired keys (like a standard cache system)
- feat: cluster mode compatibilty : the database is often locked if multiple processes try to access/update it, it's better to avoid transactions.